### PR TITLE
feat: close menu on item click

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -10,6 +10,7 @@ interface ContainerProps {
 interface ItemProps {
   readonly role: 'menuitem'
   readonly onKeyDown: (event: React.KeyboardEvent<Event>) => void
+  readonly onClick: (event: React.MouseEvent<Event>) => void
 }
 
 interface RenderOptionsProps {
@@ -181,6 +182,7 @@ class Menu extends React.Component<Props, State> {
     }
 
     const itemProps = {
+      onClick: this.close,
       onKeyDown: this.handleMenuKeys,
       role: 'menuitem' as 'menuitem'
     }


### PR DESCRIPTION
Adds an `onClick` handler to `itemProps` int order to close the menu on item click.